### PR TITLE
Blacklisted a lot of problematic bosses

### DIFF
--- a/khbr/KH2/data/enemies.yaml
+++ b/khbr/KH2/data/enemies.yaml
@@ -5133,7 +5133,7 @@ Storm Rider:
   - Shadow Stalker
   - Storm Rider
   # - Cerberus #Room is way too small for Storm Rider, which can potentially cause it to fall through the floor
-  - Terra
+  # - Terra # Ceiling is too low, can't get on his back - Kayya
 Strafer RAW:
   enabled: true
   variationof: Strafer
@@ -5428,6 +5428,8 @@ Twilight Thorn:
   room_size: 3.93
   program: 157
   type: boss
+  blacklist_destination:
+  - Scar # Tries to use the RC on you as Lion Sora due to disabled AIMod -Kayya
   whitelist_source:
   - Axel I
   - Axel II

--- a/khbr/KH2/data/enemies.yaml
+++ b/khbr/KH2/data/enemies.yaml
@@ -1355,9 +1355,13 @@ Barbossa:
     - Terra # report of crash at cutscene
   blacklist_destination:
   - Xigbar # You are put in boxed in space
+  - Thresholder # Illuminator can spawn out of bounds, softlocking unless you have very specific tools - Kayya
+  - The Beast # Illuminator can spawn out of bounds, softlocking unless you have very specific tools - Kayya
+  - Riku # Allegedly doesn't finish the fight if you kill him - Kayya
   blacklist_source:
   - Thresholder # report of fight not ending
   - Larxene # report of fight not ending
+  - Axel (Data) # Can only SOMETIMES complete the Overtaker RC which can cause a softlock if you can't complete it - Kayya
   adds:
   - ObjectId: 358 #Illuminator
     name: Illuminator
@@ -1826,6 +1830,8 @@ Axel (Data):
   enmp_index: 0xF5
   hp: 100
   level: 99
+  blacklist_destination:
+  - Luxord #Falls through arena during RC - Kayya
   limiter: 34
   model: B_EX110_LV99
   msn: TT20_MS603_RE
@@ -1924,6 +1930,8 @@ Luxord (Data):
   enmp_index: 0xF3
   hp: 100
   level: 99
+  blacklist_destination:
+  - Luxord # DM crashes - Kayya
   limiter: 0
   model: B_EX150_LV99
   msn: EH14_MS103 # TODO DUPE MSN
@@ -2075,6 +2083,7 @@ Demyx:
   type: boss
   blacklist_destination:
   - Cerberus # he might be starting in the sky causing it not to load the fight properly
+  - Armor Xemnas I # Falls down at start and softlocks the fight - Kayya
   variations:
     Demyx:
       vars:
@@ -2537,6 +2546,10 @@ Grim Reaper II:
   tags:
   - needs_rc
   level: 99
+  blacklist_source:
+  - Volcano Lord # Crashes upon entering room - Kayya
+  - Blizzard Lord # Crashes upon entering room - Kayya
+  - Hades II # Crashes upon entering room - Kayya
   blacklist_destination:
   - Dark Thorn # medals get lost on ground
   - Shadow Stalker # medals get lost on ground
@@ -2548,7 +2561,7 @@ Grim Reaper II:
   - Hades II
   - Hostile Program
   - Hydra
-  - Luxord
+  # - Luxord # RC doesn't work in this arena making the fight more tedious than it should be - Kayya
   - Pete Cups
   - Roxas
   - Saix
@@ -2805,7 +2818,7 @@ Hayner:
   - Axel II
   - Barbossa
   - Blizzard Lord
-  - Cloud
+  # - Cloud # Crashes in struggle fights - Kayya
   - Dark Thorn
   - Grim Reaper I
   - Hades II
@@ -3232,7 +3245,7 @@ Large Body:
       vars:
       - 0
       - 0
-Larxene:
+Larxene: #Breaks in some arenas due to Y level differences. Can we fix this? - Kayya
   roomData:
     bossX: -137.8426971435547
     bossY: 0
@@ -4474,6 +4487,9 @@ Scar:
   blacklist_source:
   - Shan-Yu # Reports of tpose from RC causing softlock
   - Dark Thorn # Reports of tpose from grab causing softlock
+  - The Beast # Cannot use the RC as Lion Sora which softlocks the fight - Kayya
+  - Xaldin (Data) # Invincible if he gets his wind shield up with no access to Jump, thus being a softlock - Kayya
+  - Saix (Data) # Unable to drain Berserk Gauge due to lack of Claymore, thus being a softlock - Kayya
   hp: 100
   level: 99
   limiter: 0
@@ -4517,7 +4533,7 @@ Seifer:
   - Axel II
   - Barbossa
   - Blizzard Lord
-  - Cloud
+  # - Cloud # Crashes in struggle - Kayya
   - Dark Thorn
   - Grim Reaper I
   - Hades II
@@ -4662,7 +4678,7 @@ Setzer:
   - Axel II
   - Barbossa
   - Blizzard Lord
-  - Cloud
+  # - Cloud # Crashes in struggle - Kayya
   - Dark Thorn
   - Grim Reaper I
   - Hades II
@@ -5111,12 +5127,12 @@ Storm Rider:
   - Armor Xemnas II
   - Groundshaker
   - Hydra
-  - Luxord
+  # - Luxord #Room is way too small for Storm Rider, which can potentially cause it to fall through the floor
   - Final Xemnas
   - Dark Thorn
   - Shadow Stalker
   - Storm Rider
-  - Cerberus
+  # - Cerberus #Room is way too small for Storm Rider, which can potentially cause it to fall through the floor
   - Terra
 Strafer RAW:
   enabled: true
@@ -5198,6 +5214,7 @@ The Beast:
   enmp_index: 0x49
   blacklist_source:
   - Grim Reaper II # remove once GR2 is phase 3 only
+  - Larxene # Can allegedly softlock when summoning clones - Kayya
   hp: 100
   level: 99
   limiter: 0
@@ -5518,7 +5535,7 @@ Vivi:
   - Axel II
   - Barbossa
   - Blizzard Lord
-  - Cloud
+  # - Cloud # Crashes in struggle - Kayya
   - Dark Thorn
   - Grim Reaper I
   - Hades II
@@ -5682,6 +5699,10 @@ Xigbar:
   - Roxas (Data)
   - Prison Keeper
   - The Beast
+  - Marluxia # Can teleport you out of bounds causing a softlock if he chooses to warp to the long room - Kayya
+  - Larxene # Can teleport you out of bounds causing a softlock if he chooses to warp to the long room - Kayya
+  - Lexaeus # Can teleport you out of bounds causing a softlock if he chooses to warp to the long room - Kayya
+  - Xaldin # Can teleport you out of bounds causing a softlock, unsure which room transition casues this though - Kayya
   enabled: true
   tags:
   - organization

--- a/khbr/KH2/data/full_enemy_records.json
+++ b/khbr/KH2/data/full_enemy_records.json
@@ -21485,7 +21485,6 @@
             "Terra",
             "The Experiment",
             "Tifa",
-            "Twilight Thorn",
             "Vexen",
             "Vivi",
             "Volcano Lord",
@@ -23563,8 +23562,7 @@
             "Final Xemnas",
             "Dark Thorn",
             "Shadow Stalker",
-            "Storm Rider",
-            "Terra"
+            "Storm Rider"
         ],
         "replace_as": null,
         "source_replace_allowed": true,
@@ -23921,7 +23919,6 @@
             "Setzer",
             "Shadow Stalker",
             "Shan-Yu",
-            "Storm Rider",
             "Terra",
             "The Beast",
             "The Experiment",
@@ -24689,6 +24686,9 @@
         "room_size": 3.93,
         "program": 157,
         "type": "boss",
+        "blacklist_destination": [
+            "Scar"
+        ],
         "whitelist_source": [
             "Axel I",
             "Axel II",
@@ -24738,7 +24738,6 @@
         "sizeTag": null,
         "roommaxsize": null,
         "blacklist_source": [],
-        "blacklist_destination": [],
         "whitelist_destination": [],
         "adds": [],
         "sp_ids": [],

--- a/khbr/KH2/data/full_enemy_records.json
+++ b/khbr/KH2/data/full_enemy_records.json
@@ -7360,11 +7360,15 @@
             ]
         },
         "blacklist_destination": [
-            "Xigbar"
+            "Xigbar",
+            "Thresholder",
+            "The Beast",
+            "Riku"
         ],
         "blacklist_source": [
             "Thresholder",
-            "Larxene"
+            "Larxene",
+            "Axel (Data)"
         ],
         "adds": [
             {
@@ -8229,7 +8233,6 @@
             "Sephiroth",
             "Setzer",
             "Shadow Stalker",
-            "Storm Rider",
             "The Beast",
             "The Experiment",
             "Thresholder",
@@ -9282,6 +9285,9 @@
         "enmp_index": 245,
         "hp": 100,
         "level": 99,
+        "blacklist_destination": [
+            "Luxord"
+        ],
         "limiter": 34,
         "model": "B_EX110_LV99",
         "msn": "TT20_MS603_RE",
@@ -9310,9 +9316,6 @@
         "sizeTag": null,
         "roommaxsize": null,
         "blacklist_source": [],
-        "blacklist_destination": [
-            "Scar"
-        ],
         "whitelist_source": [
             "Axel I",
             "Axel II",
@@ -9406,7 +9409,8 @@
             "Xigbar"
         ],
         "blacklist_destination": [
-            "Cerberus"
+            "Cerberus",
+            "Armor Xemnas I"
         ],
         "whitelist_source": [],
         "whitelist_destination": [],
@@ -9607,6 +9611,9 @@
         "enmp_index": 243,
         "hp": 100,
         "level": 99,
+        "blacklist_destination": [
+            "Luxord"
+        ],
         "limiter": 0,
         "model": "B_EX150_LV99",
         "msn": "EH14_MS103",
@@ -9636,7 +9643,6 @@
         "sizeTag": null,
         "roommaxsize": null,
         "blacklist_source": [],
-        "blacklist_destination": [],
         "whitelist_source": [],
         "whitelist_destination": [],
         "adds": [
@@ -9903,7 +9909,11 @@
             "Roxas",
             "Roxas (Data)",
             "Prison Keeper",
-            "The Beast"
+            "The Beast",
+            "Marluxia",
+            "Larxene",
+            "Lexaeus",
+            "Xaldin"
         ],
         "whitelist_source": [],
         "whitelist_destination": [],
@@ -9948,7 +9958,8 @@
         "program": 55,
         "type": "boss",
         "blacklist_destination": [
-            "Cerberus"
+            "Cerberus",
+            "Armor Xemnas I"
         ],
         "variations": [
             "Demyx"
@@ -12176,6 +12187,11 @@
             "needs_rc"
         ],
         "level": 99,
+        "blacklist_source": [
+            "Volcano Lord",
+            "Blizzard Lord",
+            "Hades II"
+        ],
         "blacklist_destination": [
             "Dark Thorn",
             "Shadow Stalker"
@@ -12188,7 +12204,6 @@
             "Hades II",
             "Hostile Program",
             "Hydra",
-            "Luxord",
             "Pete Cups",
             "Roxas",
             "Saix",
@@ -12221,7 +12236,6 @@
         "can_be_enemy_override": false,
         "sizeTag": null,
         "roommaxsize": null,
-        "blacklist_source": [],
         "whitelist_source": [],
         "sp_ids": [],
         "subtracts": [],
@@ -12232,7 +12246,6 @@
         "luamod": null,
         "available": [
             "Armor Xemnas II",
-            "Blizzard Lord",
             "Cloud",
             "MCP",
             "Grim Reaper I",
@@ -12253,7 +12266,6 @@
             "Thresholder",
             "Tifa",
             "Vivi",
-            "Volcano Lord",
             "Yuffie"
         ]
     },
@@ -12886,7 +12898,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -12940,7 +12951,6 @@
         "luamod": null,
         "available": [
             "Blizzard Lord",
-            "Cloud",
             "Grim Reaper I",
             "Hades II",
             "Hayner",
@@ -15475,7 +15485,6 @@
             "Volcano Lord",
             "Xaldin",
             "Xemnas",
-            "Xigbar",
             "Yuffie",
             "Zexion"
         ]
@@ -15977,7 +15986,6 @@
             "Volcano Lord",
             "Xaldin",
             "Xemnas",
-            "Xigbar",
             "Yuffie",
             "Zexion"
         ]
@@ -16487,7 +16495,6 @@
             "Final Xemnas",
             "MCP",
             "Grim Reaper I",
-            "Grim Reaper II",
             "Hades II",
             "Hayner",
             "Hercules",
@@ -16512,7 +16519,6 @@
             "Setzer",
             "Shadow Stalker",
             "Shan-Yu",
-            "Storm Rider",
             "Terra",
             "The Beast",
             "The Experiment",
@@ -16803,7 +16809,6 @@
             "Volcano Lord",
             "Xaldin",
             "Xemnas",
-            "Xigbar",
             "Yuffie",
             "Zexion"
         ]
@@ -17005,12 +17010,14 @@
             0
         ],
         "name": "Minute Bomb WI",
+        "aimods": [
+            {
+                "name": "M_EX550/m_ex.bdscript",
+                "type": "obj"
+            }
+        ],
         "enabled": true,
         "variationof": "Minute Bomb",
-        "tags": [
-            "ranged"
-        ],
-        "replace_as": "Cannon Gun",
         "enmp_index": 57,
         "hp": 100,
         "level": 99,
@@ -17022,20 +17029,16 @@
         "variations": [
             "Minute Bomb WI"
         ],
+        "replace_as": null,
         "source_replace_allowed": true,
         "msn_replace_allowed": true,
-        "category": "ranged",
+        "tags": [],
+        "category": "",
         "isnightmare": false,
         "parent": "Minute Bomb",
         "children": [],
         "msn_required": false,
         "msn_source_as": null,
-        "aimods": [
-            {
-                "name": "M_EX550/m_ex.bdscript",
-                "type": "obj"
-            }
-        ],
         "cmdmods": [],
         "mickey_source": false,
         "final_fight": false,
@@ -20764,7 +20767,6 @@
             "Armor Xemnas II",
             "Axel I",
             "Axel II",
-            "Barbossa",
             "Blizzard Lord",
             "Cerberus",
             "Cloud",
@@ -21402,7 +21404,10 @@
         ],
         "blacklist_source": [
             "Shan-Yu",
-            "Dark Thorn"
+            "Dark Thorn",
+            "The Beast",
+            "Xaldin (Data)",
+            "Saix (Data)"
         ],
         "hp": 100,
         "level": 99,
@@ -21531,7 +21536,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -21590,7 +21594,6 @@
         "available": [
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -21655,7 +21658,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -21757,7 +21759,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -21857,7 +21858,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -21958,7 +21958,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -22184,7 +22183,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -22239,7 +22237,6 @@
         "available": [
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -23563,12 +23560,10 @@
             "Armor Xemnas II",
             "Groundshaker",
             "Hydra",
-            "Luxord",
             "Final Xemnas",
             "Dark Thorn",
             "Shadow Stalker",
             "Storm Rider",
-            "Cerberus",
             "Terra"
         ],
         "replace_as": null,
@@ -23967,7 +23962,8 @@
         "enabled": true,
         "enmp_index": 73,
         "blacklist_source": [
-            "Grim Reaper II"
+            "Grim Reaper II",
+            "Larxene"
         ],
         "hp": 100,
         "level": 99,
@@ -24990,7 +24986,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -25043,7 +25038,6 @@
         "luamod": null,
         "available": [
             "Blizzard Lord",
-            "Cloud",
             "Grim Reaper I",
             "Hades II",
             "Hayner",
@@ -25383,7 +25377,6 @@
             "Volcano Lord",
             "Xaldin",
             "Xemnas",
-            "Xigbar",
             "Yuffie",
             "Zexion"
         ]
@@ -25525,7 +25518,11 @@
             "Roxas",
             "Roxas (Data)",
             "Prison Keeper",
-            "The Beast"
+            "The Beast",
+            "Marluxia",
+            "Larxene",
+            "Lexaeus",
+            "Xaldin"
         ],
         "enabled": true,
         "tags": [

--- a/khbr/KH2/data/full_enemy_records_pc.json
+++ b/khbr/KH2/data/full_enemy_records_pc.json
@@ -6642,7 +6642,6 @@
             "Cerberus",
             "Cloud",
             "Dark Thorn",
-            "Demyx",
             "Final Xemnas",
             "MCP",
             "Grim Reaper I",
@@ -7396,12 +7395,16 @@
         },
         "blacklist_destination": [
             "Xigbar",
+            "Thresholder",
+            "The Beast",
+            "Riku",
             "Luxord",
             "Terra"
         ],
         "blacklist_source": [
             "Thresholder",
-            "Larxene"
+            "Larxene",
+            "Axel (Data)"
         ],
         "adds": [
             {
@@ -8312,7 +8315,6 @@
             "Setzer",
             "Shadow Stalker",
             "Shan-Yu",
-            "Storm Rider",
             "Terra",
             "The Beast",
             "The Experiment",
@@ -9396,6 +9398,9 @@
         "enmp_index": 245,
         "hp": 100,
         "level": 99,
+        "blacklist_destination": [
+            "Luxord"
+        ],
         "limiter": 34,
         "model": "B_EX110_LV99",
         "msn": "TT20_MS603_RE",
@@ -9424,9 +9429,6 @@
         "sizeTag": null,
         "roommaxsize": null,
         "blacklist_source": [],
-        "blacklist_destination": [
-            "Scar"
-        ],
         "whitelist_source": [
             "Axel I",
             "Axel II",
@@ -9520,7 +9522,8 @@
             "Xigbar"
         ],
         "blacklist_destination": [
-            "Cerberus"
+            "Cerberus",
+            "Armor Xemnas I"
         ],
         "whitelist_source": [],
         "whitelist_destination": [],
@@ -9721,6 +9724,9 @@
         "enmp_index": 243,
         "hp": 100,
         "level": 99,
+        "blacklist_destination": [
+            "Luxord"
+        ],
         "limiter": 0,
         "model": "B_EX150_LV99",
         "msn": "EH14_MS103",
@@ -9750,7 +9756,6 @@
         "sizeTag": null,
         "roommaxsize": null,
         "blacklist_source": [],
-        "blacklist_destination": [],
         "whitelist_source": [],
         "whitelist_destination": [],
         "adds": [
@@ -10017,7 +10022,11 @@
             "Roxas",
             "Roxas (Data)",
             "Prison Keeper",
-            "The Beast"
+            "The Beast",
+            "Marluxia",
+            "Larxene",
+            "Lexaeus",
+            "Xaldin"
         ],
         "whitelist_source": [],
         "whitelist_destination": [],
@@ -10062,7 +10071,8 @@
         "program": 55,
         "type": "boss",
         "blacklist_destination": [
-            "Cerberus"
+            "Cerberus",
+            "Armor Xemnas I"
         ],
         "variations": [
             "Demyx"
@@ -12335,6 +12345,11 @@
             "needs_rc"
         ],
         "level": 99,
+        "blacklist_source": [
+            "Volcano Lord",
+            "Blizzard Lord",
+            "Hades II"
+        ],
         "blacklist_destination": [
             "Dark Thorn",
             "Shadow Stalker"
@@ -12347,7 +12362,6 @@
             "Hades II",
             "Hostile Program",
             "Hydra",
-            "Luxord",
             "Pete Cups",
             "Roxas",
             "Saix",
@@ -12380,7 +12394,6 @@
         "can_be_enemy_override": false,
         "sizeTag": null,
         "roommaxsize": null,
-        "blacklist_source": [],
         "whitelist_source": [],
         "sp_ids": [],
         "subtracts": [],
@@ -12395,7 +12408,6 @@
             "Axel I",
             "Axel II",
             "Barbossa",
-            "Blizzard Lord",
             "Cerberus",
             "Cloud",
             "Dark Thorn",
@@ -12404,7 +12416,6 @@
             "MCP",
             "Grim Reaper I",
             "Grim Reaper II",
-            "Hades II",
             "Hayner",
             "Hercules",
             "Hostile Program",
@@ -12436,7 +12447,6 @@
             "Twilight Thorn",
             "Vexen",
             "Vivi",
-            "Volcano Lord",
             "Xaldin",
             "Xemnas",
             "Xigbar",
@@ -13085,7 +13095,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -13140,7 +13149,6 @@
         "available": [
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -15732,7 +15740,6 @@
             "Volcano Lord",
             "Xaldin",
             "Xemnas",
-            "Xigbar",
             "Yuffie",
             "Zexion"
         ]
@@ -16252,7 +16259,6 @@
             "Volcano Lord",
             "Xaldin",
             "Xemnas",
-            "Xigbar",
             "Yuffie",
             "Zexion"
         ]
@@ -16761,7 +16767,6 @@
             "Final Xemnas",
             "MCP",
             "Grim Reaper I",
-            "Grim Reaper II",
             "Hades II",
             "Hayner",
             "Hercules",
@@ -16786,7 +16791,6 @@
             "Setzer",
             "Shadow Stalker",
             "Shan-Yu",
-            "Storm Rider",
             "Terra",
             "The Beast",
             "The Experiment",
@@ -17091,7 +17095,6 @@
             "Volcano Lord",
             "Xaldin",
             "Xemnas",
-            "Xigbar",
             "Yuffie",
             "Zexion"
         ]
@@ -17293,12 +17296,14 @@
             0
         ],
         "name": "Minute Bomb WI",
+        "aimods": [
+            {
+                "name": "M_EX550/m_ex.bdscript",
+                "type": "obj"
+            }
+        ],
         "enabled": true,
         "variationof": "Minute Bomb",
-        "tags": [
-            "ranged"
-        ],
-        "replace_as": "Cannon Gun",
         "enmp_index": 57,
         "hp": 100,
         "level": 99,
@@ -17310,20 +17315,16 @@
         "variations": [
             "Minute Bomb WI"
         ],
+        "replace_as": null,
         "source_replace_allowed": true,
         "msn_replace_allowed": true,
-        "category": "ranged",
+        "tags": [],
+        "category": "",
         "isnightmare": false,
         "parent": "Minute Bomb",
         "children": [],
         "msn_required": false,
         "msn_source_as": null,
-        "aimods": [
-            {
-                "name": "M_EX550/m_ex.bdscript",
-                "type": "obj"
-            }
-        ],
         "cmdmods": [],
         "mickey_source": false,
         "final_fight": false,
@@ -21141,7 +21142,6 @@
             "Armor Xemnas II",
             "Axel I",
             "Axel II",
-            "Barbossa",
             "Blizzard Lord",
             "Cerberus",
             "Cloud",
@@ -21789,7 +21789,10 @@
         ],
         "blacklist_source": [
             "Shan-Yu",
-            "Dark Thorn"
+            "Dark Thorn",
+            "The Beast",
+            "Xaldin (Data)",
+            "Saix (Data)"
         ],
         "hp": 100,
         "level": 99,
@@ -21918,7 +21921,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -21977,7 +21979,6 @@
         "available": [
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -22042,7 +22043,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -22144,7 +22144,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -22244,7 +22243,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -22345,7 +22343,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -22571,7 +22568,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -22626,7 +22622,6 @@
         "available": [
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -23992,12 +23987,10 @@
             "Armor Xemnas II",
             "Groundshaker",
             "Hydra",
-            "Luxord",
             "Final Xemnas",
             "Dark Thorn",
             "Shadow Stalker",
             "Storm Rider",
-            "Cerberus",
             "Terra"
         ],
         "replace_as": null,
@@ -24398,7 +24391,8 @@
         "enabled": true,
         "enmp_index": 73,
         "blacklist_source": [
-            "Grim Reaper II"
+            "Grim Reaper II",
+            "Larxene"
         ],
         "hp": 100,
         "level": 99,
@@ -24453,7 +24447,6 @@
             "Armor Xemnas II",
             "Axel I",
             "Axel II",
-            "Barbossa",
             "Blizzard Lord",
             "Cloud",
             "Dark Thorn",
@@ -24466,7 +24459,6 @@
             "Hercules",
             "Hostile Program",
             "Jafar",
-            "Larxene",
             "Leon",
             "Lexaeus",
             "Luxord",
@@ -24701,7 +24693,6 @@
             "Armor Xemnas II",
             "Axel I",
             "Axel II",
-            "Barbossa",
             "Blizzard Lord",
             "Cerberus",
             "Cloud",
@@ -25512,7 +25503,6 @@
             "Axel II",
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -25566,7 +25556,6 @@
         "available": [
             "Barbossa",
             "Blizzard Lord",
-            "Cloud",
             "Dark Thorn",
             "Grim Reaper I",
             "Hades II",
@@ -25924,7 +25913,6 @@
             "Volcano Lord",
             "Xaldin",
             "Xemnas",
-            "Xigbar",
             "Yuffie",
             "Zexion"
         ]
@@ -26066,7 +26054,11 @@
             "Roxas",
             "Roxas (Data)",
             "Prison Keeper",
-            "The Beast"
+            "The Beast",
+            "Marluxia",
+            "Larxene",
+            "Lexaeus",
+            "Xaldin"
         ],
         "enabled": true,
         "tags": [

--- a/khbr/KH2/data/full_enemy_records_pc.json
+++ b/khbr/KH2/data/full_enemy_records_pc.json
@@ -21870,7 +21870,6 @@
             "Terra",
             "The Experiment",
             "Tifa",
-            "Twilight Thorn",
             "Vexen",
             "Vivi",
             "Volcano Lord",
@@ -23990,8 +23989,7 @@
             "Final Xemnas",
             "Dark Thorn",
             "Shadow Stalker",
-            "Storm Rider",
-            "Terra"
+            "Storm Rider"
         ],
         "replace_as": null,
         "source_replace_allowed": true,
@@ -24350,7 +24348,6 @@
             "Setzer",
             "Shadow Stalker",
             "Shan-Yu",
-            "Storm Rider",
             "Terra",
             "The Beast",
             "The Experiment",
@@ -25194,6 +25191,9 @@
         "room_size": 3.93,
         "program": 157,
         "type": "boss",
+        "blacklist_destination": [
+            "Scar"
+        ],
         "whitelist_source": [
             "Axel I",
             "Axel II",
@@ -25243,7 +25243,6 @@
         "sizeTag": null,
         "roommaxsize": null,
         "blacklist_source": [],
-        "blacklist_destination": [],
         "whitelist_destination": [],
         "adds": [],
         "sp_ids": [],


### PR DESCRIPTION
This should make the randomizer more stable for now, reducing the chances of bosses crashing or softlocking the player. Some of these can be fixed, but until they are I believe they should remain blacklisted.